### PR TITLE
API tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Rarity levels for [Loot](https://lootproject.com) items.
 
 The rarity level of any given item is deducted from its number of occurrences in the total number of Loot items.
 
-| Rarity                                                                                                                                    | Description                                        | Occurrences           |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------- |
+| Rarity level                                                                                                                             | Description                                        | Occurrences           |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------- |
 | <img width="10" alt="" src="https://user-images.githubusercontent.com/36158/131379065-5eef7b05-458c-4717-bfa8-c2d086283f0b.png"> Level 1 | **Common** items appear **375** or more times.     | 47.25% - 30,237 items |
 | <img width="10" alt="" src="https://user-images.githubusercontent.com/36158/131379064-442c9a9e-90c9-4cb9-8fac-1ed0dbed5609.png"> Level 2 | **Uncommon** items appear less than **375** times. | 12.61% - 8,073 items  |
 | <img width="10" alt="" src="https://user-images.githubusercontent.com/36158/131379063-1b6fa149-945f-467a-893e-e90eab48c20c.png"> Level 3 | **Rare** items appear less than **358** times.     | 11.78% - 7,537 items  |
@@ -25,24 +25,119 @@ pnpm add loot-rarity # pnpm
 
 ## API
 
-```tsx
-// Rarity goes from 1 (common) to 6 (mythic).
-type Rarity = 1 | 2 | 3 | 4 | 5 | 6;
+### RarityLevel
 
-// Get the rarity of an item given its name.
-function itemRarity(itemName: string): Rarity;
+```ts
+// RarityLevel goes from 1 (common) to 6 (mythic).
+type RarityLevel = 1 | 2 | 3 | 4 | 5 | 6;
+```
 
-// Get the color of an item given its name or rarity.
-function rarityColor(itemOrRarity: string | Rarity): string;
+This type is exported and represents a rarity level. See table above for the description of each level.
 
-// Get the description of a rarity given an item name or rarity level.
-function rarityDescription(itemOrRarity: string | Rarity): string;
+### itemRarity()
 
-// Transforms an SVG image (SVG, URL or data URI) to add rarity colors.
-function imageRarity(image: string, { displayLevels?: Boolean }): Promise<string>;
+This function returns the rarity level of an item, given its name.
 
-// Generates an image with colors from a list of items.
-function imageRarityFromItems(items: string[], { displayLevels?: Boolean }): string;
+```ts
+function itemRarity(itemName: string): RarityLevel;
+```
+
+Example:
+
+```js
+let rarity = itemRarity('"Golem Roar" Studded Leather Belt of Fury');
+
+console.log(rarity); // 6
+```
+
+### rarityColor()
+
+This function returns the color of a rarity level, given an item name or a rarity level.
+
+```ts
+function rarityColor(itemOrRarityLevel: string | RarityLevel): string;
+```
+
+Example:
+
+```js
+let color = rarityColor("Ornate Belt of Perfection");
+
+console.log(color); // "#c13cff"
+```
+
+### rarityDescription()
+
+This function returns the description of a rarity level, given an item name or a rarity level.
+
+```ts
+function rarityDescription(itemOrRarityLevel: string | RarityLevel): string;
+```
+
+Example:
+
+```js
+let levelA = rarityDescription(1);
+let levelB = rarityDescription("Studded Leather Boots of Rage");
+
+console.log(levelA); // 5
+console.log(levelB); // "Legendary"
+```
+
+### rarityImage()
+
+This function generates an image with added rarity levels.
+
+It accepts any of the following:
+
+- SVG source of a Loot image.
+- Data URI representing a Loot image (e.g. as returned by the `tokenURI()` method of the Loot contract).
+- HTTP URL pointing to a Loot image.
+- Array of items.
+
+```ts
+function rarityImage(imageOrItems: string | string[], { displayLevels?: Boolean }): Promise<string>;
+```
+
+The `displayLevels` option allows to add levels to the items list.
+
+Example with React, [useNft()](https://github.com/spectrexyz/use-nft) (to load the image) and [swr](https://github.com/vercel/swr) (to handle the async function).
+
+```jsx
+import { rarityImage } from "loot-rarity";
+import { useNft } from "use-nft";
+import useSWR from "swr";
+
+function Loot({ tokenId }) {
+  const { nft } = useNft(LOOT, id);
+  const { data: image } = useSWR(nft?.image, rarityImage);
+  return image ? <img src={image} /> : <div>Loading…</div>;
+}
+```
+
+### rarityImageFromItems()
+
+This function is similar to rarityImage, except it only accepts an array of items. It is useful when you already have a list of items, because it returns a `string` directly (while `rarityImage()` returns a `Promise` resolving to a `string`).
+
+Example:
+
+```js
+import { rarityImageFromItems } from "loot-rarity";
+
+const bag = [
+  "Grimoire",
+  '"Woe Bite" Ornate Chestplate of the Fox +1',
+  "Silk Hood",
+  "Heavy Belt of Fury",
+  "Shoes",
+  "Silk Gloves",
+  '"Rune Glow" Amulet of Rage',
+  "Silver Ring",
+];
+
+document.body.innerHTML = `
+  <img src=${rarityImageFromItems(bag)} />
+`;
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The `displayLevels` option allows to add levels to the items list.
 
 The resulting images look like this:
 
-<img width="1000" alt="Illustration of how rarityImage() transforms Loot images." src="https://user-images.githubusercontent.com/36158/131524734-04b68742-7234-4667-a836-839b82745bb9.png">
+<img width="1000" alt="Illustration of how rarityImage() transforms Loot images." src="https://user-images.githubusercontent.com/36158/131525734-12f4b91c-7985-4c18-ab9d-a2a0376ed310.png">
 
 Example with React, [use-nft](https://github.com/spectrexyz/use-nft) to load the image, and [swr](https://github.com/vercel/swr) to handle the async function:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Example:
 let levelA = rarityDescription(1);
 let levelB = rarityDescription("Studded Leather Boots of Rage");
 
-console.log(levelA); // 5
+console.log(levelA); // "Common"
 console.log(levelB); // "Legendary"
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ It accepts any of the following:
 
 The `displayLevels` option allows to add levels to the items list.
 
-Example with React, [useNft()](https://github.com/spectrexyz/use-nft) (to load the image) and [swr](https://github.com/vercel/swr) (to handle the async function).
+Example with React, [useNft()](https://github.com/spectrexyz/use-nft) to load the image, and [swr](https://github.com/vercel/swr) to handle the async function:
 
 ```jsx
 import { rarityImage } from "loot-rarity";

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ It accepts any of the following:
 
 The `displayLevels` option allows to add levels to the items list.
 
-Example with React, [useNft()](https://github.com/spectrexyz/use-nft) to load the image, and [swr](https://github.com/vercel/swr) to handle the async function:
+Example with React, [use-nft](https://github.com/spectrexyz/use-nft) to load the image, and [swr](https://github.com/vercel/swr) to handle the async function:
 
 ```jsx
 import { rarityImage } from "loot-rarity";

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ This type is exported and represents a rarity level. See table above for the des
 
 ### itemRarity()
 
-This function returns the rarity level of an item, given its name.
-
 ```ts
 function itemRarity(itemName: string): RarityLevel;
 ```
+
+This function returns the rarity level of an item, given its name.
 
 Example:
 
@@ -52,11 +52,11 @@ console.log(rarity); // 6
 
 ### rarityColor()
 
-This function returns the color of a rarity level, given an item name or a rarity level.
-
 ```ts
 function rarityColor(itemOrRarityLevel: string | RarityLevel): string;
 ```
+
+This function returns the color of a rarity level, given an item name or a rarity level.
 
 Example:
 
@@ -68,11 +68,11 @@ console.log(color); // "#c13cff"
 
 ### rarityDescription()
 
-This function returns the description of a rarity level, given an item name or a rarity level.
-
 ```ts
 function rarityDescription(itemOrRarityLevel: string | RarityLevel): string;
 ```
+
+This function returns the description of a rarity level, given an item name or a rarity level.
 
 Example:
 
@@ -86,6 +86,10 @@ console.log(levelB); // "Legendary"
 
 ### rarityImage()
 
+```ts
+function rarityImage(imageOrItems: string | string[], { displayLevels?: Boolean }): Promise<string>;
+```
+
 This function generates an image with added rarity levels.
 
 It accepts any of the following:
@@ -94,10 +98,6 @@ It accepts any of the following:
 - Data URI representing a Loot image (e.g. as returned by the `tokenURI()` method of the Loot contract).
 - HTTP URL pointing to a Loot image.
 - Array of items.
-
-```ts
-function rarityImage(imageOrItems: string | string[], { displayLevels?: Boolean }): Promise<string>;
-```
 
 The `displayLevels` option allows to add levels to the items list.
 
@@ -116,6 +116,10 @@ function Loot({ tokenId }) {
 ```
 
 ### rarityImageFromItems()
+
+```ts
+function rarityImageFromItems(items: string[], { displayLevels?: Boolean }): string;
+```
 
 This function is similar to rarityImage, except it only accepts an array of items. It is useful when you already have a list of items, because it returns a `string` directly (while `rarityImage()` returns a `Promise` resolving to a `string`).
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ It accepts any of the following:
 
 The `displayLevels` option allows to add levels to the items list.
 
+The resulting images look like this:
+
+<img width="1000" alt="Illustration of how rarityImage() transforms Loot images." src="https://user-images.githubusercontent.com/36158/131524734-04b68742-7234-4667-a836-839b82745bb9.png">
+
 Example with React, [use-nft](https://github.com/spectrexyz/use-nft) to load the image, and [swr](https://github.com/vercel/swr) to handle the async function:
 
 ```jsx

--- a/scripts/rarity-distribution.ts
+++ b/scripts/rarity-distribution.ts
@@ -1,6 +1,6 @@
 import occurences from "../data/occurences.json";
 import { scoreFromOccurences } from "./utils";
-import { rarityDescription, Rarity } from "../src";
+import { rarityDescription, RarityLevel } from "../src";
 import rarityLevels from "../src/rarity-levels";
 
 type Occurences = Record<string, number>;
@@ -24,7 +24,7 @@ async function main() {
   console.log("");
 
   levels.forEach((items, index) => {
-    const description = rarityDescription((index + 1) as Rarity);
+    const description = rarityDescription((index + 1) as RarityLevel);
     const percentage = Math.round((items / total) * 10000) / 100;
     const threshold = rarityLevels[index][0];
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,7 +1,8 @@
-import type { Rarity } from "./types";
+import type { RarityLevel } from "./types";
 
 import { itemRarity } from "./index";
 import rarityLevels from "./rarity-levels";
+import { warnDeprecatedName } from "./utils";
 
 export function svgFromItems(
   items: string[],
@@ -10,7 +11,7 @@ export function svgFromItems(
     displayLevels = false,
   }: {
     displayLevels?: boolean;
-    levels?: Rarity[];
+    levels?: RarityLevel[];
   } = {}
 ) {
   if (items.length !== 8) {
@@ -19,7 +20,7 @@ export function svgFromItems(
   const levelStyles = levels
     ? rarityLevels
         .map(([_, color], index) => {
-          return !levels.includes((index + 1) as Rarity)
+          return !levels.includes((index + 1) as RarityLevel)
             ? ""
             : `.level-${index + 1} { fill: ${color}; }`;
         })
@@ -80,7 +81,7 @@ export function isUri(data: string) {
   return /^(?:https?|data)\:/.test(data);
 }
 
-export function imageRarityFromItems(
+export function rarityImageFromItems(
   items: string[],
   { displayLevels = false }: { displayLevels?: boolean } = {}
 ): string {
@@ -92,19 +93,39 @@ export function imageRarityFromItems(
   );
 }
 
-export async function imageRarity(
-  svgOrSvgUri: string,
+export async function rarityImage(
+  svgOrSvgUriOrItems: string | string[],
   { displayLevels = false }: { displayLevels?: boolean } = {}
 ): Promise<string> {
-  const svg = isUri(svgOrSvgUri)
-    ? await fetch(svgOrSvgUri).then((res) => res.text())
-    : svgOrSvgUri;
+  if (Array.isArray(svgOrSvgUriOrItems)) {
+    return rarityImageFromItems(svgOrSvgUriOrItems);
+  }
+
+  const svg = isUri(svgOrSvgUriOrItems)
+    ? await fetch(svgOrSvgUriOrItems).then((res) => res.text())
+    : svgOrSvgUriOrItems;
 
   if (!svg.startsWith("<svg")) {
     throw new Error(
-      "The image doesn’t seem to be an SVG or a URL pointing to an SVG"
+      "The resource doesn’t seem to be an SVG or a URL pointing to an SVG"
     );
   }
 
-  return imageRarityFromItems(itemsFromSvg(svg), { displayLevels });
+  return rarityImageFromItems(itemsFromSvg(svg), { displayLevels });
+}
+
+// deprecated
+
+export function imageRarityFromItems(
+  ...params: Parameters<typeof rarityImageFromItems>
+): ReturnType<typeof rarityImageFromItems> {
+  warnDeprecatedName("imageRarityFromItems()", "rarityImageFromItems()");
+  return rarityImageFromItems(...params);
+}
+
+export function imageRarity(
+  ...params: Parameters<typeof rarityImage>
+): ReturnType<typeof rarityImage> {
+  warnDeprecatedName("imageRarity()", "rarityImage()");
+  return rarityImage(...params);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Rarity } from "./types";
+import type { Rarity, RarityLevel } from "./types";
 
 import itemsRarity from "../data/items-rarity-hashes.json";
 import { hashItem } from "./hash-item";
@@ -7,13 +7,15 @@ import {
   imageRarity,
   imageRarityFromItems,
   itemsFromSvg,
+  rarityImage,
+  rarityImageFromItems,
   svgDataUri,
   svgFromItems,
 } from "./image";
 
 let cachedItemsrarity = null;
 
-export function itemRarity(itemName: string): Rarity {
+export function itemRarity(itemName: string): RarityLevel {
   if (!cachedItemsrarity) {
     cachedItemsrarity = itemsRarity.map(
       (items: string) => new Set(items.match(/.{1,5}/g))
@@ -25,14 +27,14 @@ export function itemRarity(itemName: string): Rarity {
   let index = 6;
   while (index--) {
     if (cachedItemsrarity[index].has(hash)) {
-      return (index + 1) as Rarity;
+      return (index + 1) as RarityLevel;
     }
   }
 
   throw new Error(`The item name couldn’t be found: “${itemName}”`);
 }
 
-export function rarityColor(itemOrRarity: string | Rarity): string {
+export function rarityColor(itemOrRarity: string | RarityLevel): string {
   const rarity =
     typeof itemOrRarity === "number" ? itemOrRarity : itemRarity(itemOrRarity);
 
@@ -43,7 +45,7 @@ export function rarityColor(itemOrRarity: string | Rarity): string {
   return color;
 }
 
-export function rarityDescription(itemOrRarity: string | Rarity): string {
+export function rarityDescription(itemOrRarity: string | RarityLevel): string {
   const rarity =
     typeof itemOrRarity === "number" ? itemOrRarity : itemRarity(itemOrRarity);
 
@@ -54,12 +56,14 @@ export function rarityDescription(itemOrRarity: string | Rarity): string {
   return description;
 }
 
-export type { Rarity };
+export type { Rarity, RarityLevel };
 export { rarityLevels };
 export {
   imageRarity,
   imageRarityFromItems,
   itemsFromSvg,
+  rarityImage,
+  rarityImageFromItems,
   svgDataUri,
   svgFromItems,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,6 @@
-export type Rarity = 1 | 2 | 3 | 4 | 5 | 6;
+export type RarityLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * @deprecated Please use RarityLevel instead
+ */
+export type Rarity = RarityLevel

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+let _warned = new Map();
+export function warnDeprecatedName(oldName: string, newName: string): void {
+  if (!_warned.get(oldName)) {
+    console.warn(
+      `${oldName} is deprecated and will be removed in a future version, please use ${newName} instead.`
+    );
+    _warned.set(oldName, true);
+  }
+}


### PR DESCRIPTION
- `Rarity` becomes `RarityLevel`
- `imageRarity()` becomes `rarityImage()`
- `imageRarityFromItems()` becomes `rarityImageFromItems()`

The previous exports are marked as deprecated and will be available until 3.0.0